### PR TITLE
Add PLpgSQL language support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "SSPL-1.0",
       "dependencies": {
+        "@derekstride/tree-sitter-sql": "^0.3.11",
         "@elastic/elasticsearch": "^9.1.1",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.52.0",
@@ -179,6 +180,31 @@
       "peerDependencies": {
         "postcss-selector-parser": "^7.0.0"
       }
+    },
+    "node_modules/@derekstride/tree-sitter-sql": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@derekstride/tree-sitter-sql/-/tree-sitter-sql-0.3.11.tgz",
+      "integrity": "sha512-YRtTXVWK4n7/3BUGchhGcW/IF1u2ldR2fd0t3Uw7ymbGXcRfiG3v1T6N43jQKXz2LwN+Nx+Ab96T0HtusBVH9g==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0",
+        "node-gyp-build": "^4.8.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@derekstride/tree-sitter-sql/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/@elastic/elasticsearch": {
       "version": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "tree-sitter": "^0.25.0"
   },
   "dependencies": {
+    "@derekstride/tree-sitter-sql": "^0.3.11",
     "@elastic/elasticsearch": "^9.1.1",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-logs-otlp-http": "^0.52.0",

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -14,6 +14,7 @@ import { handlebarsConfig } from './handlebars';
 import { cConfig } from './c';
 import { cppConfig } from './cpp';
 import { bashConfig } from './bash';
+import { plpgsqlConfig } from './plpgsql';
 import { LanguageConfiguration } from '../utils/parser';
 import {
   validateLanguageConfiguration,
@@ -37,6 +38,7 @@ export const languageConfigurations = {
   c: cConfig,
   cpp: cppConfig,
   bash: bashConfig,
+  plpgsql: plpgsqlConfig,
 } as const;
 
 /**

--- a/src/languages/plpgsql.ts
+++ b/src/languages/plpgsql.ts
@@ -1,0 +1,34 @@
+import { LanguageConfiguration } from '../utils/parser';
+import sql from '@derekstride/tree-sitter-sql';
+
+export const plpgsqlConfig: LanguageConfiguration = {
+  name: 'plpgsql',
+  fileSuffixes: ['.sql', '.pgsql', '.plpgsql'],
+  parser: sql,
+  queries: [
+    '(create_function) @function',
+    '(create_table) @table',
+    '(create_type) @type',
+    '(create_view) @view',
+    '(invocation) @call',
+    '(comment_statement) @comment',
+    '(comment) @comment',
+  ],
+  // This grammar currently does not expose a stable create_procedure node.
+  // CREATE PROCEDURE commonly parses as ERROR, so procedure extraction is out of scope.
+  symbolQueries: [
+    '(create_function (object_reference name: (identifier) @function.name))',
+    '(create_table (object_reference name: (identifier) @table.name))',
+    '(create_type (object_reference name: (identifier) @type.name))',
+    '(create_view (object_reference name: (identifier) @view.name))',
+    '(invocation (object_reference name: (identifier) @function.call))',
+  ],
+  exportQueries: [
+    '(create_function (object_reference name: (identifier) @export.name))',
+    '(create_table (object_reference name: (identifier) @export.name))',
+    '(create_type (object_reference name: (identifier) @export.name))',
+    '(create_view (object_reference name: (identifier) @export.name))',
+  ],
+  // Omitted importQueries intentionally: SQL/PLpgSQL set/search-path/schema references do not map
+  // cleanly to canonical module/file imports in this parser, similar to Scala's limitations.
+};

--- a/src/types/tree-sitter-sql.d.ts
+++ b/src/types/tree-sitter-sql.d.ts
@@ -1,0 +1,1 @@
+declare module '@derekstride/tree-sitter-sql';

--- a/tests/fixtures/plpgsql.sql
+++ b/tests/fixtures/plpgsql.sql
@@ -1,0 +1,25 @@
+-- PLpgSQL fixture for parser tests
+CREATE TYPE status_enum AS ENUM ('active', 'inactive');
+
+CREATE TABLE accounts (
+  account_id SERIAL PRIMARY KEY,
+  owner_name TEXT NOT NULL,
+  status status_enum NOT NULL DEFAULT 'active',
+  balance NUMERIC(12, 2) NOT NULL DEFAULT 0
+);
+
+CREATE OR REPLACE FUNCTION calculate_bonus(base_amount NUMERIC, multiplier NUMERIC)
+RETURNS NUMERIC
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN base_amount * multiplier;
+END;
+$$;
+
+CREATE VIEW active_accounts AS
+SELECT account_id, owner_name, balance
+FROM accounts
+WHERE status = 'active';
+
+SELECT calculate_bonus(100, 1.25);

--- a/tests/unit/__snapshots__/parser.test.ts.snap
+++ b/tests/unit/__snapshots__/parser.test.ts.snap
@@ -9893,6 +9893,241 @@ This is another paragraph.
 ]
 `;
 
+exports[`LanguageParser > should parse PLpgSQL fixtures correctly 1`] = `
+[
+  {
+    "chunk_hash": "7532810589e16686ea1bdd29781d441d91f39dbc21079b7ab4412b5202df1075",
+    "containerPath": "",
+    "content": "-- PLpgSQL fixture for parser tests",
+    "created_at": "[TIMESTAMP]",
+    "directoryDepth": 2,
+    "directoryName": "fixtures",
+    "directoryPath": "tests/fixtures",
+    "endLine": 1,
+    "exports": [],
+    "filePath": "tests/fixtures/plpgsql.sql",
+    "git_branch": "main",
+    "git_file_hash": "2fca3e07cf5c8ae311ecdbfe64c89a8ae8d3b884",
+    "imports": [],
+    "kind": "comment",
+    "language": "plpgsql",
+    "semantic_text": "language: plpgsql
+kind: comment
+
+-- PLpgSQL fixture for parser tests",
+    "startLine": 1,
+    "symbols": [],
+    "type": "code",
+    "updated_at": "[TIMESTAMP]",
+  },
+  {
+    "chunk_hash": "86d2af1627ba1b59c6712d912d0882ac36f46302b7f1645a8ac3324c901b6837",
+    "containerPath": "",
+    "content": "CREATE TYPE status_enum AS ENUM ('active', 'inactive')",
+    "created_at": "[TIMESTAMP]",
+    "directoryDepth": 2,
+    "directoryName": "fixtures",
+    "directoryPath": "tests/fixtures",
+    "endLine": 2,
+    "exports": [
+      {
+        "name": "status_enum",
+        "type": "named",
+      },
+    ],
+    "filePath": "tests/fixtures/plpgsql.sql",
+    "git_branch": "main",
+    "git_file_hash": "2fca3e07cf5c8ae311ecdbfe64c89a8ae8d3b884",
+    "imports": [],
+    "kind": "create_type",
+    "language": "plpgsql",
+    "semantic_text": "language: plpgsql
+kind: create_type
+
+CREATE TYPE status_enum AS ENUM ('active', 'inactive')",
+    "startLine": 2,
+    "symbols": [
+      {
+        "kind": "type.name",
+        "line": 2,
+        "name": "status_enum",
+      },
+    ],
+    "type": "code",
+    "updated_at": "[TIMESTAMP]",
+  },
+  {
+    "chunk_hash": "58dca34acb6892274f3da2fe5f08ff7c21ee81464a6245d05ea5f961fe86cdfb",
+    "containerPath": "",
+    "content": "CREATE TABLE accounts (
+  account_id SERIAL PRIMARY KEY,
+  owner_name TEXT NOT NULL,
+  status status_enum NOT NULL DEFAULT 'active',
+  balance NUMERIC(12, 2) NOT NULL DEFAULT 0
+)",
+    "created_at": "[TIMESTAMP]",
+    "directoryDepth": 2,
+    "directoryName": "fixtures",
+    "directoryPath": "tests/fixtures",
+    "endLine": 9,
+    "exports": [
+      {
+        "name": "accounts",
+        "type": "named",
+      },
+    ],
+    "filePath": "tests/fixtures/plpgsql.sql",
+    "git_branch": "main",
+    "git_file_hash": "2fca3e07cf5c8ae311ecdbfe64c89a8ae8d3b884",
+    "imports": [],
+    "kind": "create_table",
+    "language": "plpgsql",
+    "semantic_text": "language: plpgsql
+kind: create_table
+
+CREATE TABLE accounts (
+  account_id SERIAL PRIMARY KEY,
+  owner_name TEXT NOT NULL,
+  status status_enum NOT NULL DEFAULT 'active',
+  balance NUMERIC(12, 2) NOT NULL DEFAULT 0
+)",
+    "startLine": 4,
+    "symbols": [
+      {
+        "kind": "table.name",
+        "line": 4,
+        "name": "accounts",
+      },
+    ],
+    "type": "code",
+    "updated_at": "[TIMESTAMP]",
+  },
+  {
+    "chunk_hash": "36d6be09744926d7845851b9595946e146f4ed609d63a52450b4c99374da7f5f",
+    "containerPath": "",
+    "content": "CREATE OR REPLACE FUNCTION calculate_bonus(base_amount NUMERIC, multiplier NUMERIC)
+RETURNS NUMERIC
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN base_amount * multiplier;
+END;
+$$",
+    "created_at": "[TIMESTAMP]",
+    "directoryDepth": 2,
+    "directoryName": "fixtures",
+    "directoryPath": "tests/fixtures",
+    "endLine": 18,
+    "exports": [
+      {
+        "name": "calculate_bonus",
+        "type": "named",
+      },
+    ],
+    "filePath": "tests/fixtures/plpgsql.sql",
+    "git_branch": "main",
+    "git_file_hash": "2fca3e07cf5c8ae311ecdbfe64c89a8ae8d3b884",
+    "imports": [],
+    "kind": "create_function",
+    "language": "plpgsql",
+    "semantic_text": "language: plpgsql
+kind: create_function
+
+CREATE OR REPLACE FUNCTION calculate_bonus(base_amount NUMERIC, multiplier NUMERIC)
+RETURNS NUMERIC
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN base_amount * multiplier;
+END;
+$$",
+    "startLine": 11,
+    "symbols": [
+      {
+        "kind": "function.name",
+        "line": 11,
+        "name": "calculate_bonus",
+      },
+    ],
+    "type": "code",
+    "updated_at": "[TIMESTAMP]",
+  },
+  {
+    "chunk_hash": "fe6133d2bf92d1b6624038a7d4b912b395a22da6947e1a63a429b55b42b6de06",
+    "containerPath": "",
+    "content": "CREATE VIEW active_accounts AS
+SELECT account_id, owner_name, balance
+FROM accounts
+WHERE status = 'active'",
+    "created_at": "[TIMESTAMP]",
+    "directoryDepth": 2,
+    "directoryName": "fixtures",
+    "directoryPath": "tests/fixtures",
+    "endLine": 23,
+    "exports": [
+      {
+        "name": "active_accounts",
+        "type": "named",
+      },
+    ],
+    "filePath": "tests/fixtures/plpgsql.sql",
+    "git_branch": "main",
+    "git_file_hash": "2fca3e07cf5c8ae311ecdbfe64c89a8ae8d3b884",
+    "imports": [],
+    "kind": "create_view",
+    "language": "plpgsql",
+    "semantic_text": "language: plpgsql
+kind: create_view
+
+CREATE VIEW active_accounts AS
+SELECT account_id, owner_name, balance
+FROM accounts
+WHERE status = 'active'",
+    "startLine": 20,
+    "symbols": [
+      {
+        "kind": "view.name",
+        "line": 20,
+        "name": "active_accounts",
+      },
+    ],
+    "type": "code",
+    "updated_at": "[TIMESTAMP]",
+  },
+  {
+    "chunk_hash": "755ae962a59d1afb00907b9ec58f93561e24634fa8f88a4908dcddec27fb1de8",
+    "containerPath": "",
+    "content": "calculate_bonus(100, 1.25)",
+    "created_at": "[TIMESTAMP]",
+    "directoryDepth": 2,
+    "directoryName": "fixtures",
+    "directoryPath": "tests/fixtures",
+    "endLine": 25,
+    "exports": [],
+    "filePath": "tests/fixtures/plpgsql.sql",
+    "git_branch": "main",
+    "git_file_hash": "2fca3e07cf5c8ae311ecdbfe64c89a8ae8d3b884",
+    "imports": [],
+    "kind": "invocation",
+    "language": "plpgsql",
+    "semantic_text": "language: plpgsql
+kind: invocation
+
+calculate_bonus(100, 1.25)",
+    "startLine": 25,
+    "symbols": [
+      {
+        "kind": "function.call",
+        "line": 25,
+        "name": "calculate_bonus",
+      },
+    ],
+    "type": "code",
+    "updated_at": "[TIMESTAMP]",
+  },
+]
+`;
+
 exports[`LanguageParser > should parse Properties fixtures correctly 1`] = `
 [
   {

--- a/tests/unit/languages.test.ts
+++ b/tests/unit/languages.test.ts
@@ -129,4 +129,15 @@ describe('parseLanguageNames', () => {
     const allLanguages = Object.keys(languageConfigurations);
     expect(allLanguages).toContain('bash');
   });
+
+  it('should parse plpgsql language', () => {
+    const result = parseLanguageNames('plpgsql');
+    expect(result).toEqual(['plpgsql']);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should include plpgsql in supported languages', () => {
+    const allLanguages = Object.keys(languageConfigurations);
+    expect(allLanguages).toContain('plpgsql');
+  });
 });

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -25,6 +25,7 @@ const TEST_LANGUAGES = [
   'c',
   'cpp',
   'bash',
+  'plpgsql',
 ].join(',');
 
 describe('LanguageParser', () => {
@@ -293,6 +294,51 @@ Content 2`;
     const result = parser.parseFile(hbsFile, 'main', 'tests/fixtures/handlebars.hbs');
     expect(result.chunks.length).toBeGreaterThan(0);
     expect(result.chunks[0].language).toBe('handlebars');
+  });
+
+  it('should recognize .sql file extension as plpgsql', () => {
+    const sqlFile = path.resolve(__dirname, '../fixtures/plpgsql.sql');
+    const result = parser.parseFile(sqlFile, 'main', 'tests/fixtures/plpgsql.sql');
+    expect(result.chunks.length).toBeGreaterThan(0);
+    expect(result.chunks[0].language).toBe('plpgsql');
+    expect(result.metrics.parserType).toBe('tree-sitter');
+  });
+
+  it('should extract symbols from PLpgSQL fixtures correctly', () => {
+    const filePath = path.resolve(__dirname, '../fixtures/plpgsql.sql');
+    const result = parser.parseFile(filePath, 'main', 'tests/fixtures/plpgsql.sql');
+    const allSymbols = result.chunks.flatMap((chunk) => chunk.symbols);
+
+    expect(allSymbols).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'status_enum', kind: 'type.name' }),
+        expect.objectContaining({ name: 'accounts', kind: 'table.name' }),
+        expect.objectContaining({ name: 'active_accounts', kind: 'view.name' }),
+        expect.objectContaining({ name: 'calculate_bonus', kind: 'function.name' }),
+        expect.objectContaining({ name: 'calculate_bonus', kind: 'function.call' }),
+      ])
+    );
+  });
+
+  it('should extract exports from PLpgSQL fixtures correctly', () => {
+    const filePath = path.resolve(__dirname, '../fixtures/plpgsql.sql');
+    const result = parser.parseFile(filePath, 'main', 'tests/fixtures/plpgsql.sql');
+    const allExports = result.chunks.flatMap((chunk) => chunk.exports || []);
+
+    expect(allExports).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'status_enum', type: 'named' }),
+        expect.objectContaining({ name: 'accounts', type: 'named' }),
+        expect.objectContaining({ name: 'active_accounts', type: 'named' }),
+        expect.objectContaining({ name: 'calculate_bonus', type: 'named' }),
+      ])
+    );
+  });
+
+  it('should parse PLpgSQL fixtures correctly', () => {
+    const filePath = path.resolve(__dirname, '../fixtures/plpgsql.sql');
+    const result = parser.parseFile(filePath, 'main', 'tests/fixtures/plpgsql.sql');
+    expect(cleanTimestamps(result.chunks)).toMatchSnapshot();
   });
 
   it('should parse C fixtures correctly', () => {


### PR DESCRIPTION
## Summary
- add PLpgSQL language support using @derekstride/tree-sitter-sql
- register .sql, .pgsql, and .plpgsql extensions
- add fixture coverage, parser tests, language tests, and snapshot coverage

## Validation
- npm run build
- npm test
- npm run lint